### PR TITLE
feat(docs): indicate ga status

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/memorystore/docs/memcached",
   "client_documentation": "https://googleapis.dev/nodejs/memcache/latest/index.html",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5169231",
-  "release_level": "beta",
+  "release_level": "ga",
   "language": "nodejs",
   "repo": "googleapis/nodejs-memcache",
   "distribution_name": "@google-cloud/memcache",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Memorystore for Memcached: Node.js Client](https://github.com/googleapis/nodejs-memcache)
 
-[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/memcache.svg)](https://www.npmjs.org/package/@google-cloud/memcache)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-memcache/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-memcache)
 
@@ -109,11 +109,12 @@ _Legacy Node.js versions are supported as a best effort:_
 This library follows [Semantic Versioning](http://semver.org/).
 
 
+This library is considered to be **General Availability (GA)**. This means it
+is stable; the code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **GA** libraries
+are addressed with the highest priority.
 
-This library is considered to be in **beta**. This means it is expected to be
-mostly stable while we work toward a general availability release; however,
-complete stability is not guaranteed. We will address issues and requests
-against beta libraries with a high priority.
 
 
 

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-memcache.git",
-        "sha": "105dc474f33479cca0888116a9d63a4f9abc59ac"
+        "remote": "git@github.com:googleapis/nodejs-memcache.git",
+        "sha": "5ce7bfd3950eb62f000ba862b72df9349546ef8d"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "d99d5d592f3d1d5526511c90120b1e9ab3ce6e17",
-        "internalRef": "354148500"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "57c23fa5705499a4181095ced81f0ee0933b64f6"
+        "sha": "d1ec8a4330fdc131e49637ed34bb031695a89060",
+        "internalRef": "360235141"
       }
     }
   ],


### PR DESCRIPTION
The API surface is now GA.